### PR TITLE
Add: installation guideline for Windows Defender users

### DIFF
--- a/source/getting-started/install.rst
+++ b/source/getting-started/install.rst
@@ -133,6 +133,9 @@ The installation of Exegol on Linux, macOS and Windows are very similar. It can 
 
            python3 -m pip install exegol
 
+        .. warning::
+
+            You may want to disable Windows Defender during the installation, as Exegol will download pre-built remote shells. You should also add the folder ``C:\Users\<user>\.exegol\exegol-resources`` to the exclution list.
 
     ..  group-tab:: Installing from sources
 


### PR DESCRIPTION
Windows Defender users may not be able to install Exegol with pip install as it will attempt to download remote shells.
These files will be flagged by WD and will stop the installation.
It may be good to tell the users of Exegol to disable WD (and add the folder containing said remote shells to the exclusion list) before proceeding to the installation.