### PR TITLE
fix end of line in the doc for neovim configuration

### DIFF
--- a/source/exegol-image/my-resources.rst
+++ b/source/exegol-image/my-resources.rst
@@ -148,6 +148,7 @@ Exegol supports overwriting its **vim** configuration to allow all users to use 
     Will be available from version ``3.1.2`` of any exegol image.
 
 Exegol supports overwriting its **neovim** configuration to allow all users to use their personal configuration.
+
 * To automatically overwrite the ``~/.config/nvim/`` configuration, copy your config in  ``/opt/my-resources/setup/nvim/``
 
 .. tip::


### PR DESCRIPTION
missing end of line
![image](https://github.com/ThePorgs/Exegol-docs/assets/62119053/893c8360-181a-427a-9761-ddafc86fc710)