### PR TITLE
Add OrbStack informations

### DIFF
--- a/source/getting-started/install.rst
+++ b/source/getting-started/install.rst
@@ -90,6 +90,8 @@ Additional dependencies may be required depending on the host OS.
 
             `OrbStack <https://orbstack.dev/>`__ for **Mac** is supported by Exegol wrapper from ``v4.2.0``.
 
+            Your exegol installation cannot be stored under ``/opt`` directory when using OrbStack.
+
             This support is still in beta, feel free to open issues on `GitHub <https://github.com/ThePorgs/Exegol/issues/new/choose>`__ if you encounter any bugs.
 
     ..  group-tab:: Windows


### PR DESCRIPTION
Hello,

I've seen that it's not possible to install exegol in the `/opt` folder from a Mac running OrbStack.
But this is not indicated in the documentation.

*cf: <https://github.com/ThePorgs/Exegol/tree/master/exegol/model#L958>*