### PR TITLE
Remove doc versionning

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -10,7 +10,7 @@ import datetime
 project = 'Exegol'
 copyright = f'{datetime.datetime.now().year}, Shutdown & Dramelac'
 author = 'Shutdown & Dramelac'
-release = '4.1.0'
+# release = '4.1.0'  # Disable version for doc
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/getting-started/install.rst
+++ b/source/getting-started/install.rst
@@ -90,6 +90,8 @@ Additional dependencies may be required depending on the host OS.
 
             `OrbStack <https://orbstack.dev/>`__ for **Mac** is supported by Exegol wrapper from ``v4.2.0``.
 
+            Your exegol installation cannot be stored under ``/opt`` directory when using OrbStack (`due to OrbStack limitations <https://github.com/orbstack/orbstack/issues/435>`_).
+
             This support is still in beta, feel free to open issues on `GitHub <https://github.com/ThePorgs/Exegol/issues/new/choose>`__ if you encounter any bugs.
 
     ..  group-tab:: Windows


### PR DESCRIPTION
Because we are handling 2 project at the same time (wrapper / image).
Removing for now the versioning of the doc (currently 4.1.0 in page title of every page).

Plus add warning for `/opt` orbstack install 