### PR TITLE
Add useful aliases and a FAQ for Responder

### DIFF
--- a/source/getting-started/faq.rst
+++ b/source/getting-started/faq.rst
@@ -103,3 +103,8 @@ How to retrieve your desktop login details ?
 The container's root password can be obtained with ``exegol info <container>`` (i.e. this is needed when using the :doc:`desktop </the-exegol-project/python-wrapper>` feature)
 
 .. TODO: add a note, when the Desktop feature is in prod, that explains the ups and dows of X11 vs. Desktop mode.
+
+Fixing Responder's limited packet capture on macOS
+==================================================
+
+To resolve this issue, use the ``--externalip=$YourLocalIP`` option. This option allows Responder to capture all packets on your local network, rather than limiting itself to local broadcast protocols like NetBIOS.

--- a/source/getting-started/faq.rst
+++ b/source/getting-started/faq.rst
@@ -103,8 +103,3 @@ How to retrieve your desktop login details ?
 The container's root password can be obtained with ``exegol info <container>`` (i.e. this is needed when using the :doc:`desktop </the-exegol-project/python-wrapper>` feature)
 
 .. TODO: add a note, when the Desktop feature is in prod, that explains the ups and dows of X11 vs. Desktop mode.
-
-Fixing Responder's limited packet capture on macOS
-==================================================
-
-To resolve this issue, use the ``--externalip=$YourLocalIP`` option. This option allows Responder to capture all packets on your local network, rather than limiting itself to local broadcast protocols like NetBIOS.

--- a/source/getting-started/tips-and-tricks.rst
+++ b/source/getting-started/tips-and-tricks.rst
@@ -110,6 +110,8 @@ Network related
 * ``ipr``: List network routes in short and colorful way
 * ``pc``: Shortcut to ``proxychains``
 * ``ncvz``: Shortcut to test an open TCP port
+* ``tun0``: IP address of the tun0 interface
+* ``eth0``: IP address of the eth0 interface
 
 Shell
 -----

--- a/source/getting-started/troubleshooting.rst
+++ b/source/getting-started/troubleshooting.rst
@@ -121,3 +121,7 @@ To correct this problem, simply disable this feature on the Exegol repository an
     git rm -rf --cached .
     git reset --hard HEAD
 
+Fixing Responder's limited packet capture on macOS
+==================================================
+
+To resolve this issue, use the ``--externalip=$YourLocalIP`` option. This option allows Responder to capture all packets on your local network, rather than limiting itself to local broadcast protocols like NetBIOS.


### PR DESCRIPTION
Hi 👋,

I have added aliases from PR [#388](https://github.com/ThePorgs/Exegol-images/pull/388). In the FAQ, I added the issue reported by **V3locidad** on Discord, where Responder only receives NBT packets on macOS.