### PR TITLE
feat(wrapper): Add zellij (terminal multiplexer like tmux)

### DIFF
--- a/source/exegol-image/my-resources.rst
+++ b/source/exegol-image/my-resources.rst
@@ -259,6 +259,14 @@ Exegol supports overloading its **tmux** configuration to allow all users to use
 .. tip::
     It is possible to install **plugins** with the APT customization system, details :ref:`here <custom_apt>`.
 
+:code:`zellij` (conf)
+~~~~~~~~~~~~~~~~~~~
+.. seealso::
+    Available from version ``X.X.X`` of any exegol image.
+
+Exegol supports overloading its **zellij** configuration to allow all users to use their personal configuration.
+
+* To automatically overwrite the ``~/.config/zellij/config.kdl`` configuration file, simply create the file ``/opt/my-resources/setup/zellij/config.kdl``
 
 :code:`vim` (vimrc, configs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/exegol-wrapper/start.rst
+++ b/source/exegol-wrapper/start.rst
@@ -151,7 +151,7 @@ Command examples
    # Create a container app with custom volume
    exegol start app full -V "/var/app/:/app/"
 
-   # Get a shell based on tmux
+   # Get a shell based on tmux or zellij
    exegol start --shell tmux
 
    # Share a specific hardware device (like Proxmark)
@@ -159,4 +159,3 @@ Command examples
 
    # Share every USB device connected to the host
    exegol start -d "/dev/bus/usb/"
-

--- a/source/the-exegol-project/python-wrapper.rst
+++ b/source/the-exegol-project/python-wrapper.rst
@@ -278,7 +278,7 @@ The shell logging method can be selected manually with the :ref:`start action <s
         .. warning::
             Shell logging saves **EVERYTHING** including keyboard shortcuts, display refreshes, etc.
 
-            Complex graphical environments (such as tmux) can make it difficult to read the logs.
+            Complex graphical environments (such as tmux or zellij) can make it difficult to read the logs.
 
 
 .. _feature_shared_network:


### PR DESCRIPTION
# Description

This adds the `zellij` command line option `--shell` which allows to select this new terminal multiplexer shell environment at startup. 

See: https://github.com/ThePorgs/Exegol/pull/263 and https://github.com/ThePorgs/Exegol-images/pull/514