### PR TITLE
NixOS install - Adding nix native path

### DIFF
--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -38,7 +38,7 @@ environment.systemPackages = with pkgs; [
 ```
 
 > [!WARNING]
-> The exegol package in nixpkgs is not maintained by the Exegol team. Packaging issues should be reported to the nixpkgs maintainers. You can still ask on Discord, but support for this specific packaging path is best-effort.
+> The exegol package in nixpkgs is not maintained by the Exegol team. Packaging issues should be reported to the `nixpkgs` maintainers. Questions may be asked on Discord, but support for this packaging path is provided on a best-effort basis.
 
 Save the file with [CTRL] + [O], press [ENTER], and exit with [CTRL] + [X]. Then rebuild your system:
 
@@ -47,7 +47,7 @@ sudo nixos-rebuild switch
 ```
 
 > [!TIP]
-> Using flakes ? Add `pkgs.exegol` and `pkgs.git` in your flake’s NixOS module the same way, then:
+> Using flakes ? Add `pkgs.exegol` and `pkgs.git` in the flake’s NixOS module in the same way, then:
 > ```bash
 > sudo nixos-rebuild switch --flake .#your-host
 > ```
@@ -56,7 +56,7 @@ sudo nixos-rebuild switch
 
 From most stable to least stable option:
 
-1. Use a newer channel (e.g., `nixos-unstable`) for just this package:
+1. A newer channel (e.g., `nixos-unstable`) can be used for just this package:
   ```nix
   let
     unstable = import <nixos-unstable> { };
@@ -66,9 +66,9 @@ From most stable to least stable option:
     ];
   }
   ```
-  > You can also switch your whole system to `nixos-unstable`, but that affects everything.
-2. If your target version isn't in `nixpkgs` yet:
-  - Copy the Exegol derivation from a PR or a staging branch into your config
+  > The whole system can also be switched to `nixos-unstable`, but that affects everything.
+2. If the target version is not yet present in `nixpkgs`:
+  - The Exegol derivation can be copied from a PR or a staging branch into the configuration.
   - Write your own derivation pointing to the desired source/version
 
 > [!NOTE]
@@ -112,7 +112,7 @@ sudo nixos-rebuild switch
 ```
 
 > [!TIP]
-> Using flakes ? Add `pkgs.git`, `pkgs.python3` and `pkgs.pipx` in your flake’s NixOS module the same way, then:
+> Using flakes ? Add `pkgs.git`, `pkgs.python3` and `pkgs.pipx` in the flake’s NixOS module in the same way, then:
 > ```bash
 > sudo nixos-rebuild switch --flake .#your-host
 > ```

--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -29,7 +29,7 @@ Add the following lines (or merge with your existing configuration):
 environment.systemPackages = with pkgs; [
   exegol
 ];
-  virtualisation.docker = {
+virtualisation.docker = {
   enable = true;
   # Do NOT enable rootless here — Exegol doesn’t support Docker rootless mode
   rootless.enable = false; # (false is the default)
@@ -106,7 +106,14 @@ environment.systemPackages = with pkgs; [
 ];
 virtualisation.docker = {
   enable = true;
+  # Do NOT enable rootless here — Exegol doesn’t support Docker rootless mode
+  rootless.enable = false; # (false is the default)
 };
+```
+
+To run Exegol without sudo, the user must be a member of the docker group. This can be declared in the NixOS configuration:
+```nix
+users.users.<user>.extraGroups = [ "docker" ];
 ```
 
 Save the file with [CTRL] + [O], press [ENTER], and exit with [CTRL] + [X].

--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -17,7 +17,7 @@ This approach keeps your system declarative and reproducible: all changes live i
 
 ### Enable Docker & install Exegol
 
-`git`, `exegol` and the Docker engine can be installed by editing your NixOS configuration:
+`exegol` and the Docker engine can be installed by editing your NixOS configuration:
 
 ```bash
 sudo nano /etc/nixos/configuration.nix

--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -28,13 +28,17 @@ Add the following lines (or merge with your existing configuration):
 ```bash
 environment.systemPackages = with pkgs; [
   exegol
-  git
 ];
   virtualisation.docker = {
   enable = true;
   # Do NOT enable rootless here — Exegol doesn’t support Docker rootless mode
   rootless.enable = false; # (false is the default)
 };
+```
+
+To run Exegol without sudo, the user must be a member of the docker group. This can be declared in the NixOS configuration:
+```nix
+users.users.<user>.extraGroups = [ "docker" ];
 ```
 
 > [!WARNING]
@@ -51,6 +55,8 @@ sudo nixos-rebuild switch
 > ```bash
 > sudo nixos-rebuild switch --flake .#your-host
 > ```
+
+After rebuilding, log out and back in (or run newgrp docker) so the new group membership takes effect.
 
 ### Need a newer Exegol wrapper via `nixpkgs`?
 

--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -51,7 +51,7 @@ sudo nixos-rebuild switch
 ```
 
 > [!TIP]
-> Using flakes ? Add `pkgs.exegol` and `pkgs.git` in the flake’s NixOS module in the same way, then:
+> Using flakes ? Add `pkgs.exegol` in the flake’s NixOS module in the same way, then:
 > ```bash
 > sudo nixos-rebuild switch --flake .#your-host
 > ```

--- a/docs/src/install/on-nixos.md
+++ b/docs/src/install/on-nixos.md
@@ -3,12 +3,86 @@
 > [!NOTE]
 > This page was brought to you by a community member and wasn't "mass-tested" yet. Feedback on whether it works properly (or not) would be greatly appreciated (please head over to our Discord server for that).
 
+> [!IMPORTANT]
+> This page focuses on the NixOS way (declarative and reproducible) and also documents an alternative with pipx. Because NixOS is all about reproducibility, the "nix way" comes first. Please note that the official and recommended way to install Exegol is over pipx. 
+
 Exegol is installed through two main steps:
 
 1. Install the Python wrapper (the "brains")
 2. Install at least one Exegol image (the "muscle")
 
-## 1. Requirements
+## 1. NixOS-native
+
+This approach keeps your system declarative and reproducible: all changes live in your Nix configuration.
+
+### Enable Docker & install Exegol
+
+`git`, `exegol` and the Docker engine can be installed by editing your NixOS configuration:
+
+```bash
+sudo nano /etc/nixos/configuration.nix
+```
+
+Add the following lines (or merge with your existing configuration):
+
+```bash
+environment.systemPackages = with pkgs; [
+  exegol
+  git
+];
+  virtualisation.docker = {
+  enable = true;
+  # Do NOT enable rootless here — Exegol doesn’t support Docker rootless mode
+  rootless.enable = false; # (false is the default)
+};
+```
+
+> [!WARNING]
+> The exegol package in nixpkgs is not maintained by the Exegol team. Packaging issues should be reported to the nixpkgs maintainers. You can still ask on Discord, but support for this specific packaging path is best-effort.
+
+Save the file with [CTRL] + [O], press [ENTER], and exit with [CTRL] + [X]. Then rebuild your system:
+
+```bash
+sudo nixos-rebuild switch
+```
+
+> [!TIP]
+> Using flakes ? Add `pkgs.exegol` and `pkgs.git` in your flake’s NixOS module the same way, then:
+> ```bash
+> sudo nixos-rebuild switch --flake .#your-host
+> ```
+
+### Need a newer Exegol wrapper via `nixpkgs`?
+
+From most stable to least stable option:
+
+1. Use a newer channel (e.g., `nixos-unstable`) for just this package:
+  ```nix
+  let
+    unstable = import <nixos-unstable> { };
+  in {
+    environment.systemPackages = with pkgs; [
+      unstable.exegol
+    ];
+  }
+  ```
+  > You can also switch your whole system to `nixos-unstable`, but that affects everything.
+2. If your target version isn't in `nixpkgs` yet:
+  - Copy the Exegol derivation from a PR or a staging branch into your config
+  - Write your own derivation pointing to the desired source/version
+
+> [!NOTE]
+> Prefer these Nix-friendly options over [`pipx`](/on-nixos#_2-portable-alternative) only if you care about reproducibility. 
+
+### Next
+
+Once the wrapper and docker are installed, the main installation documentation can be followed, from [step "3. Activation"](/first-install#_3-activation).
+
+## 2. `pipx` alternative
+
+### Enable prerequisite
+
+If you need the very latest wrapper immediately and can accept a non-declarative/non-reproducible setup:
 
 `git`, `python3`, `pipx`, and the Docker engine can be installed by editing your NixOS configuration:
 
@@ -18,16 +92,15 @@ sudo nano /etc/nixos/configuration.nix
 
 Add the following lines (or merge with your existing configuration):
 
-```bash
-  environment.systemPackages = with pkgs; [
+```nix
+environment.systemPackages = with pkgs; [
   git
   python3
   pipx 
- ];
-   virtualisation.docker = {
-    enable = true;
-  };
-
+];
+virtualisation.docker = {
+  enable = true;
+};
 ```
 
 Save the file with [CTRL] + [O], press [ENTER], and exit with [CTRL] + [X].
@@ -38,18 +111,17 @@ Then apply the changes:
 sudo nixos-rebuild switch
 ```
 
-Ensure `pipx` is in PATH and reload the shell
+> [!TIP]
+> Using flakes ? Add `pkgs.git`, `pkgs.python3` and `pkgs.pipx` in your flake’s NixOS module the same way, then:
+> ```bash
+> sudo nixos-rebuild switch --flake .#your-host
+> ```
 
+Ensure pipx is in PATH and reload the shell
 ```bash
 pipx ensurepath && exec $SHELL
 ```
 
-While we always advise to refer to the [official documentation](https://docs.docker.com/engine/install/)
-
-
-> [!WARNING]
-> Docker "[Rootless mode](https://docs.docker.com/engine/security/rootless/)" is not supported by Exegol as of yet. Don't follow that part.
-
-## 2. The rest
+### Next
 
 Once the requirements are installed, the main installation documentation can be followed, from [step "2. Wrapper install"](/first-install#_2-wrapper-install).


### PR DESCRIPTION
# Summary
This PR rewrites the “Installing Exegol on NixOS” page to highlight the NixOS-native (declarative) method first, while preserving a pipx alternative. 

# Why
NixOS prioritizes reproducibility. Installing outside `nixpkgs` is non-declarative and considered _impure_. This PR add an alternative installation path that is closer to the "nix way"