### PR TITLE
fix: pin workflow actions to commit SHA

### DIFF
--- a/.github/workflows/automerger.yml
+++ b/.github/workflows/automerger.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set Git config
       run: |
           git config --local user.email "actions@github.com"

--- a/.github/workflows/entrypoint_release.yml
+++ b/.github/workflows/entrypoint_release.yml
@@ -9,13 +9,13 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         run: npm install && npm run docs:build
       - name: Copy redirects file
         run: cp cloudflare_redirects docs/.vitepress/dist/_redirects
       - name: Publish
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
# Description
Tags and branches in GitHub are mutable; a repository owner or an attacker who gains access to the upstream action repository can move a tag to a different commit. This creates a supply chain risk where malicious code could be introduced into our CI/CD environment without changing our workflow files.

# Related issues
None found.

# Point of attention
Make sure that the pinned versions are correct.